### PR TITLE
chore: support  npm v7+

### DIFF
--- a/all/package.json
+++ b/all/package.json
@@ -46,7 +46,7 @@
     "@types/koa-views": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
-    "eslint": "^7.0.0",
+    "eslint": "^6.0.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-typescript": "^0.14.0",

--- a/standard/package.json
+++ b/standard/package.json
@@ -43,7 +43,7 @@
     "@types/koa-views": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
-    "eslint": "^7.0.0",
+    "eslint": "^6.0.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-typescript": "^0.14.0",


### PR DESCRIPTION
degrade eslint version to ^6